### PR TITLE
Fixes bug in bazefetcher output

### DIFF
--- a/camille/output/bazefetcher.py
+++ b/camille/output/bazefetcher.py
@@ -154,8 +154,8 @@ class Bazefetcher:
     def __call__(self,
                  series,
                  tag,
-                 start=datetime.datetime(1677, 9, 22, tzinfo=pytz.utc),
-                 end=datetime.datetime(2262, 4, 11, tzinfo=pytz.utc),
+                 start=None,
+                 end=None,
                  overwrite=False):
         """
         Parameters


### PR DESCRIPTION
Default values were added for the start and end parameters. This broke
the automatic detection of these values that was triggered in the case
where they were None