### PR TITLE
Fixes bug caused by float roundoff to zero

### DIFF
--- a/camille/process/mooring_fatigue.py
+++ b/camille/process/mooring_fatigue.py
@@ -60,9 +60,10 @@ def _calc_damage(data):
     stress_ranges = []
     cycles = []
     for low, high, mult in rainflow.extract_cycles(data, True, True):
-        cycles.append(mult)
         amplitude = high - 0.5 * (high + low)
-        if amplitude > 0: stress_ranges.append( 2*amplitude )
+        if amplitude > 0:
+            cycles.append(mult)
+            stress_ranges.append( 2*amplitude )
 
     N = sn_curve(stress_ranges, logA=math.log10(6e10), m=3, t=0, tref=25, k=0)
     damage = sum(sorted(cycles/N))

--- a/tests/process/test_mooring_fatigue.py
+++ b/tests/process/test_mooring_fatigue.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import numpy as np
 import pandas as pd
+import pytest
 
 from camille import process
 from camille.process.mooring_fatigue import _calculate_stress
@@ -54,6 +55,16 @@ def test_index_set_to_window_start():
 def test_calc_damage():
     damage = _calc_damage(refcase)
     assert np.allclose( damage, 1.34471920175778e-010 )
+
+
+def test_floating_point_roundoff_causing_unexpected_zero():
+    try:
+        _calc_damage(np.array([22.169702635236565, 22.16970263523657,
+                               22.169702635236565, 22.16970263523657],
+                               dtype=np.float64))
+    except ValueError:
+        pytest.fail("Exception raised, possibly caused by floating point "
+                    "roundoff creating unexpected zero value")
 
 
 def test_nan():


### PR DESCRIPTION
Running the mooring fatigue processor on data with very small
differences caused an unexpected zero value due to floating point
roundoff.

connects to equinor/camille-notebooks#19