### PR TITLE
Partial time series fill

### DIFF
--- a/camille/output/bazefetcher.py
+++ b/camille/output/bazefetcher.py
@@ -5,46 +5,6 @@ import pandas as pd
 from camille.source.bazefetcher import _tidy_frame
 
 
-def _to_midnight_utc(timestamp):
-    """ Copied from bazefetcher, logic modified
-
-    Converts a timestamp to an UTC timestamp, to midnight of the
-    given date (00:00:00). All timestamps are converted to UTC if they
-    have timezone information, and assumed to already be UTC if they
-    have no timezone information.
-    """
-    try:
-        timestamp = pytz.utc.localize(timestamp)
-    except ValueError:
-        timestamp = timestamp.astimezone(pytz.utc)
-    timestamp = timestamp.replace(hour=0, minute=0, second=0, microsecond=0)
-    return timestamp
-
-
-def _daterange(start_date, end_date):
-    """
-    Generates dates in range between start_date and end_date with one
-    day difference starting from start_date.
-    First calls _to_midnight_utc on both.
-    :param start_date: Start date timestamp, inclusive.
-    :param end_date: End date timestamp, exclusive. Note, that if end
-    time date is later than midnight of that day, the midnight date
-    will be generated. If the date is exactly at midninght,
-    it's not generated
-    :return:
-    """
-    if start_date != end_date:
-        is_end_on_midnight = _to_midnight_utc(end_date) == end_date
-        start_date = _to_midnight_utc(start_date)
-        end_date = _to_midnight_utc(end_date)
-        if is_end_on_midnight:
-            end_date -= datetime.timedelta(days=1)
-        while start_date <= end_date:
-            next_day = start_date + datetime.timedelta(days=1)
-            yield (start_date, next_day)
-            start_date = next_day
-
-
 def _generate_tag_location(
     root, tag_name, start_date, end_date, full_path=True, suffix=".json"
     ):

--- a/camille/source/bazefetcher.py
+++ b/camille/source/bazefetcher.py
@@ -80,8 +80,8 @@ def _get_fn_regex(tag):
 
 def _get_files_between_start_and_end(src_dirs, tag, start_date, end_date):
     return _get_files(src_dirs, tag, _get_fn_regex(tag),
-                       lambda fn : _fn_start_date(fn) < end_date
-                                   and start_date < _fn_end_date(fn))
+        lambda fn: _fn_start_date(fn) < end_date
+               and _fn_end_date(fn) > start_date)
 
 
 def _extend_bwd(start_date, df, src_dirs, tag, fn_regex, tzinfo):


### PR DESCRIPTION
Bazefetcher output now lets you write into existing time series, but while keeping existing indices.