### PR TITLE
Add TagNotFoundError for tag misses in Bazefetcher

### DIFF
--- a/camille/source/__init__.py
+++ b/camille/source/__init__.py
@@ -15,7 +15,7 @@ Available functions
 """
 
 
-from .bazefetcher import Bazefetcher
+from .bazefetcher import Bazefetcher, TagNotFoundError
 from .windiris import windiris
 
 

--- a/camille/source/bazefetcher.py
+++ b/camille/source/bazefetcher.py
@@ -7,6 +7,8 @@ import pandas as pd
 from collections import abc
 from math import ceil
 
+class TagNotFoundError(ValueError):
+    pass
 
 date_pattern = r'[0-9]{4}-[0-9]{2}-[0-9]{2}'
 time_pattern = r'[0-9]{2}\.[0-9]{2}\.[0-9]{2}\+[0-9]{2}\.[0-9]{2}'
@@ -55,7 +57,7 @@ def _get_files(src_dirs, tag, fn_regex, date_pred):
     tag_roots = list(filter(isdir, (join(dr, tag) for dr in src_dirs)))
 
     if not tag_roots:
-        raise ValueError('Tag {} not found in {}'.format(tag, src_dirs))
+        raise TagNotFoundError('Tag {} not found in {}'.format(tag, src_dirs))
 
     files = [join(r, fn) for r in tag_roots for fn in os.listdir(r)
              if fn_regex.match(fn) and date_pred(fn)]

--- a/tests/source/test_bazefetcher.py
+++ b/tests/source/test_bazefetcher.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from camille.source import Bazefetcher
+from camille.source import Bazefetcher, TagNotFoundError
 from camille.source.bazefetcher import _get_files_between_start_and_end
 from datetime import datetime, timedelta
 from math import pi
@@ -110,7 +110,7 @@ def test_no_directories():
             in str(excinfo.value))
 
 def test_non_existing_tag():
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(TagNotFoundError) as excinfo:
         baze('non-existing-tag', t1_1, t1_1_1)
     assert 'Tag non-existing-tag not found' in str(excinfo.value)
 


### PR DESCRIPTION
Being able to detect and recover from missing tags is quite useful for
downstream users working with multiple similar-but-not-quite data
sources. By adding TagNotFoundError, users can mechanically determine if
this is a soft input error (missing tags) that can be recovered from, or
more severe errors that require aborts.