### PR TITLE
Running tests with version of pytest >= 4.0.0 don't fail any more

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-#pytest==3.10.1
+pytest>=6.2.2
 pytest-repeat
 hypothesis
 scikit-build

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest==3.10.1
+#pytest==3.10.1
 pytest-repeat
 hypothesis
 scikit-build


### PR DESCRIPTION
Remove pytest requirement from requirement-dev.txt.
Pytest versions 4,5 and 6 supported.